### PR TITLE
Hide `die`, since it’s included in base 4.8+.

### DIFF
--- a/GhcEvents.hs
+++ b/GhcEvents.hs
@@ -17,7 +17,7 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe
 import System.IO
-import System.Exit
+import System.Exit hiding (die)
 
 main = getArgs >>= command
 


### PR DESCRIPTION
I figured hiding the symbol was preferable to removing the `die` defined in this module, as it should be backwards-compatible to older versions of `base`, but I haven’t actually tested that hypothesis.